### PR TITLE
Add error traceability logging

### DIFF
--- a/app/assets/javascripts/magic_lamp/genie.js
+++ b/app/assets/javascripts/magic_lamp/genie.js
@@ -41,7 +41,12 @@
 
     preload: function() {
       var xhr = this.xhrRequest(getPath());
-      this.cache = JSON.parse(xhr.responseText);
+      try {
+        this.cache = JSON.parse(xhr.responseText);
+      } catch (error) {
+        console.error('The response could not be parsed: responseText="' + xhr.responseText + '", error="' + error.message + '"')
+        throw error
+      }
       this.cacheOnly = true;
     },
 

--- a/app/assets/javascripts/magic_lamp/genie.js
+++ b/app/assets/javascripts/magic_lamp/genie.js
@@ -95,6 +95,7 @@
       if (this.xhrStatus(xhr) === 400) {
         this.handleError(xhr.responseText);
       } else if (this.xhrStatus(xhr) > 400) {
+        console.error('Unexpected error: status=' + this.xhrStatus(xhr) + ', responseText="' + xhr.responseText + '"')
         this.handleError(MagicLamp.genericError);
       }
       return xhr;

--- a/spec/javascripts/genie_spec.js
+++ b/spec/javascripts/genie_spec.js
@@ -199,6 +199,22 @@ describe('Genie', function() {
       expect(subject.cacheOnly).to.equal(false);
     });
 
+    it('does not set cacheOnly to true if the response cannot be parsed', function() {
+      var path = MagicLamp.path = '/normal_lamp';
+      stub(subject, 'xhrRequest', { responseText: '<html></html>' });
+      stub(console, 'error', true);
+
+      expect(function() { subject.preload(); }).to.throw();
+      expect(subject.xhrRequest).to.have.been.calledWith(path);
+      expect(subject.cacheOnly).to.equal(false);
+      expect(console.error).to.have.been.calledWith(
+        'The response could not be parsed: responseText="<html></html>", error="JSON Parse error: Unrecognized token \'<\'"'
+      );
+
+      delete MagicLamp.path;
+      console.error.restore();
+    });
+
     it('makes a request to the specified path if defined', function() {
       var path = MagicLamp.path = '/normal_lamp';
       stub(subject, 'xhrRequest', { responseText: '{}' });

--- a/spec/javascripts/genie_spec.js
+++ b/spec/javascripts/genie_spec.js
@@ -343,17 +343,23 @@ describe('Genie', function() {
     it('calls handleError with the default error message if the status was 500', function() {
       stub(subject, 'handleError', true);
       stub(subject, 'xhrStatus', 500);
+      stub(console, 'error', true)
       var path = '/magic_lamp/foo/bar';
       subject.xhrRequest(path);
       expect(subject.handleError).to.have.been.calledWith(MagicLamp.genericError);
+      expect(console.error).to.have.been.calledWith('Unexpected error: status=500, responseText="\'foo/bar\' is not a registered fixture"');
+      console.error.restore();
     });
 
     it('calls handleError with the default error message if the status was 404', function() {
       stub(subject, 'handleError', true);
       stub(subject, 'xhrStatus', 404);
+      stub(console, 'error', true)
       var path = '/magic_lamp/foo/bar';
       subject.xhrRequest(path);
       expect(subject.handleError).to.have.been.calledWith(MagicLamp.genericError);
+      expect(console.error).to.have.been.calledWith('Unexpected error: status=404, responseText="\'foo/bar\' is not a registered fixture"');
+      console.error.restore();
     });
   });
 


### PR DESCRIPTION
👋 This is a small proposal for adding error logging to aid debugging issues when something goes wrong. 

I noticed that the library doesn't do any logging like this, so it might not make sense. But I went with this approach because it doesn't seem fitting to include for example `responseText` in an `Error` message either.

What do you think @crismali?

